### PR TITLE
Forwarded times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worksmith_rascal",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Rascal activites for worksmith",
   "main": "index.js",
   "scripts": {

--- a/src/tasks/log.js
+++ b/src/tasks/log.js
@@ -9,7 +9,7 @@ module.exports = function define(node) {
         execute.annotations = { inject: ['level', 'message', 'data', 'logger'] }
 
         function execute(level, message, data, logger, done) {
-            
+
             logger = logger || context.logger || console
 
             var recovery = get(context, 'message.properties.headers.rascal.recovery')

--- a/src/tasks/log.js
+++ b/src/tasks/log.js
@@ -1,19 +1,25 @@
 'use strict'
 
 var assignIn = require('lodash.assignin')
+var get = require('lodash.get')
 
 module.exports = function define(node) {
     return function build(context) {
 
-        execute.annotations = {inject: ['level', 'message', 'data', 'logger']}
+        execute.annotations = { inject: ['level', 'message', 'data', 'logger'] }
 
         function execute(level, message, data, logger, done) {
-
+            
             logger = logger || context.logger || console
+
+            var recovery = get(context, 'message.properties.headers.rascal.recovery')
+            var originalQueue = get(context, 'message.properties.headers.rascal.originalQueue')
+            var timesForwarded = recovery && recovery[originalQueue] && recovery[originalQueue].forwarded || 0
 
             logger[level || 'info'](message, assignIn({
                 messageId: context.message.properties.messageId,
-                routingKey: context.message.fields.routingKey
+                routingKey: context.message.fields.routingKey,
+                timesForwarded: timesForwarded,
             }, data))
             done()
         }

--- a/tests/tasks/log.test.js
+++ b/tests/tasks/log.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+var assert = require('assert')
+var worksmith = require('worksmith')
+var rascal = require('rascal')
+var _ = require('lodash')
+
+describe('log message', () => {
+
+  it.only('should fail if no message has been received', function (done) {
+
+    var workflow = worksmith({
+      task: 'sequence',
+      items: [{
+        task: 'log',
+        message: 'this is a test message string',
+      }]
+    })
+
+    var ctx = {}
+
+    workflow(ctx, function (err) {
+      assert.ok(err)
+      done()
+    })
+  })
+
+  it.only('should not throw any error if the message is correct and the message received has not been forwarded', function (done) {
+
+    var workflow = worksmith({
+      task: 'sequence',
+      items: [{
+        task: 'log',
+        message: 'this is a test message string',
+      }]
+    })
+
+    var ctx = {
+      message: {
+        properties: {
+          messageId: 'myMessageId',
+          headers: {
+            rascal: {
+              originalQueue: 'this:is:a:queue',
+            }
+          }
+        },
+        fields: {
+          routingKey: 'a.b.c.d'
+        }
+      }
+    }
+
+    workflow(ctx, function (err) {
+      assert.ifError(err)
+      done()
+    })
+  })
+
+  it.only('should not throw any error if the message is correct', function (done) {
+
+    var workflow = worksmith({
+      task: 'sequence',
+      items: [{
+        task: 'log',
+        message: 'this is a test message string',
+      }]
+    })
+
+    var ctx = {
+      message: {
+        properties: {
+          messageId: 'myMessageId',
+          headers: {
+            rascal: {
+              originalQueue: 'this:is:a:queue',
+              recovery: {
+                'this:is:a:queue': {
+                  forwarded: 9
+                }
+              }
+            }
+          }
+        },
+        fields: {
+          routingKey: 'a.b.c.d'
+        }
+      }
+    }
+
+    workflow(ctx, function (err) {
+      assert.ifError(err)
+      done()
+    })
+  })
+})

--- a/tests/tasks/log.test.js
+++ b/tests/tasks/log.test.js
@@ -7,7 +7,7 @@ var _ = require('lodash')
 
 describe('log message', () => {
 
-  it.only('should fail if no message has been received', function (done) {
+  it('should fail if no message has been received', function (done) {
 
     var workflow = worksmith({
       task: 'sequence',
@@ -25,7 +25,7 @@ describe('log message', () => {
     })
   })
 
-  it.only('should not throw any error if the message is correct and the message received has not been forwarded', function (done) {
+  it('should not throw any error if the message is correct and the message received has not been forwarded', function (done) {
 
     var workflow = worksmith({
       task: 'sequence',
@@ -57,7 +57,7 @@ describe('log message', () => {
     })
   })
 
-  it.only('should not throw any error if the message is correct', function (done) {
+  it('should not throw any error if the message is correct', function (done) {
 
     var workflow = worksmith({
       task: 'sequence',


### PR DESCRIPTION
To be squashed and merged.

We think it would be a good idea to add the number of times a message has been forwarded for easing debugging. So you can easily watch in the log if the message is being retried or it is the first attempt.